### PR TITLE
remove direct getter of properties

### DIFF
--- a/deeptrack/optics.py
+++ b/deeptrack/optics.py
@@ -687,11 +687,11 @@ class Brightfield(Optics):
 
         if not kwargs.get("return_field", False):
             output_image = np.square(np.abs(output_image))
-        else:
-            # Fudge factor. Not sure why this is needed.
-            output_image = output_image - 1
-            output_image = output_image * np.exp(1j * -np.pi / 4)
-            output_image = output_image + 1
+        # else:
+        # Fudge factor. Not sure why this is needed.
+        # output_image = output_image - 1
+        # output_image = output_image * np.exp(1j * -np.pi / 4)
+        # output_image = output_image + 1
 
         output_image.properties = illuminated_volume.properties
 

--- a/deeptrack/scatterers.py
+++ b/deeptrack/scatterers.py
@@ -585,9 +585,7 @@ class MieScatterer(Scatterer):
             )
         return properties
 
-    def get_xy_size(self):
-        output_region = self.properties["output_region"]()
-        padding = self.properties["padding"]()
+    def get_xy_size(self, output_region, padding):
         return (
             output_region[2] - output_region[0] + padding[0] + padding[2],
             output_region[3] - output_region[1] + padding[1] + padding[3],
@@ -639,11 +637,12 @@ class MieScatterer(Scatterer):
         working_distance,
         position_objective,
         return_fft,
+        output_region,
         **kwargs,
     ):
 
         # Get size of the output
-        xSize, ySize = self.get_xy_size()
+        xSize, ySize = self.get_xy_size(output_region, padding)
         voxel_size = get_active_voxel_size()
         arr = pad_image_to_fft(np.zeros((xSize, ySize))).astype(complex)
         arr = image.maybe_cupy(arr)


### PR DESCRIPTION
Fix for using miescatterers with the Repeat feature.

This will be a reoccurring problem due to the high complexity of the Repeat feature.
Currently we pass around a _ID which allows deeptrack to figure out what to recalculate and what to cache.
However keeping track of this _ID is not trivial, and antithetical to the direction I want to move deeptrack syntax towards.

I've tried solving this issue before. But it is an extremely complex problem.