### PR TITLE
Change loss input order of CGAN and PCGAN

### DIFF
--- a/deeptrack/models/gans/cgan.py
+++ b/deeptrack/models/gans/cgan.py
@@ -104,8 +104,8 @@ class CGAN(tf.keras.Model):
             shape = tf.shape(disc_pred_real)
             valid, fake = tf.ones(shape), tf.zeros(shape)
             d_loss = (
-                self.discriminator.compiled_loss(disc_pred_real, valid)
-                + self.discriminator.compiled_loss(disc_pred_fake, fake)
+                self.discriminator.compiled_loss(valid, disc_pred_real)
+                + self.discriminator.compiled_loss(fake, disc_pred_fake)
             ) / 2
 
         # Compute gradient and apply gradient
@@ -124,8 +124,8 @@ class CGAN(tf.keras.Model):
             batch_y_copies = [batch_y] * (self.num_losses - 1)
 
             g_loss = self.assemble.compiled_loss(
-                [assemble_output[0], *generated_image_copies],
                 [valid, *batch_y_copies],
+                [assemble_output[0], *generated_image_copies],
             )
 
         # Compute gradient and apply gradient

--- a/deeptrack/models/gans/pcgan.py
+++ b/deeptrack/models/gans/pcgan.py
@@ -64,7 +64,7 @@ class PCGAN(tf.keras.Model):
         metrics=[],
         **kwargs
     ):
-        super(PCGAN).__init__()
+        super().__init__()
 
         # Build and compile the discriminator
         self.discriminator = discriminator
@@ -146,8 +146,8 @@ class PCGAN(tf.keras.Model):
             shape = tf.shape(disc_pred_1)
             valid, fake = tf.ones(shape), tf.zeros(shape)
             d_loss = (
-                self.discriminator.compiled_loss(disc_pred_1, valid)
-                + self.discriminator.compiled_loss(disc_pred_2, fake)
+                self.discriminator.compiled_loss(valid, disc_pred_1)
+                + self.discriminator.compiled_loss(fake, disc_pred_2)
             ) / 2
 
         # Compute gradient and apply gradient
@@ -168,12 +168,12 @@ class PCGAN(tf.keras.Model):
             batch_y_copies = [batch_y] * (self.num_losses - 1)
 
             g_loss = self.assemble.compiled_loss(
+                [valid, perceptual_valid, *batch_y_copies],
                 [
                     assemble_output[0],
                     assemble_output[1],
                     *generated_image_copies,
                 ],
-                [valid, perceptual_valid, *batch_y_copies],
             )
 
         # Compute gradient and apply gradient


### PR DESCRIPTION
The inputs given when calling all loss_functions in both CGAN and PCGAN were written backwards, i.e. `loss_function(y_pred, y_true)` instead of the correct `loss_function(y_true, y_pred)`. This lead to negative loss values when using BinaryCrossentropyLoss.

I also updated `super(PCGAN).__init__()` to `super().__init__()`